### PR TITLE
Correção do bug de esquecimento de senha

### DIFF
--- a/forget/forget.js
+++ b/forget/forget.js
@@ -61,10 +61,11 @@ function abrirChamado(idUser){
       console.log("Problema de acesso!")
     }else if(response.status === 404){
       alert("Usuario não encontrado!");
+    }else if(response.ok){
+      return response.json();
     }else{
       throw new Error("Erro ao tentar abrir o chamado!");
     }
-    return response.json();
   })
   .then(data => {
     console.log("Chamado criado com sucesso: ", data);


### PR DESCRIPTION
Estava ocorrendo um erro ao abrir um chamado automaticamente, ocorria por conta da falta de captura de uma resposta caso ocorre-se um 200 ok. Isso implicou na funcionalidade de edição de um chamado. Um chamado que havia sido aberto automaticamente não podia ser editado, modificando seu status 